### PR TITLE
Add duplicate handling and extend Hobby creation feature

### DIFF
--- a/src/main/java/com/codecool/getalife/controller/CategoryController.java
+++ b/src/main/java/com/codecool/getalife/controller/CategoryController.java
@@ -30,10 +30,7 @@ public class CategoryController {
     }
 
     @PostMapping
-    public ResponseEntity<CategoryNameResponse> create(
-            @RequestBody CategoryCreateRequest req
-    ) {
-        var response = categoryService.create(req);
-        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    public ResponseEntity<CategoryNameResponse> create(@RequestBody CategoryCreateRequest req) {
+        return ResponseEntity.status(HttpStatus.CREATED).body(categoryService.create(req));
     }
 }

--- a/src/main/java/com/codecool/getalife/controller/CategoryController.java
+++ b/src/main/java/com/codecool/getalife/controller/CategoryController.java
@@ -31,7 +31,6 @@ public class CategoryController {
 
     @PostMapping
     public ResponseEntity<CategoryNameResponse> create(@RequestBody CategoryCreateRequest req) {
-        var response = categoryService.create(req);
-        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+        return ResponseEntity.status(HttpStatus.CREATED).body(categoryService.create(req));
     }
 }

--- a/src/main/java/com/codecool/getalife/controller/HobbyController.java
+++ b/src/main/java/com/codecool/getalife/controller/HobbyController.java
@@ -27,7 +27,7 @@ public class HobbyController {
     }
 
     @PostMapping
-    public ResponseEntity<HobbyResponse> create(@RequestBody HobbyCreateRequest request) {
-        return ResponseEntity.status(HttpStatus.CREATED).body(hobbyService.create(request));
+    public ResponseEntity<HobbyResponse> create(@RequestBody HobbyCreateRequest req) {
+        return ResponseEntity.status(HttpStatus.CREATED).body(hobbyService.create(req));
     }
 }

--- a/src/main/java/com/codecool/getalife/controller/advice/HobbyControllerAdvice.java
+++ b/src/main/java/com/codecool/getalife/controller/advice/HobbyControllerAdvice.java
@@ -1,6 +1,7 @@
 package com.codecool.getalife.controller.advice;
 
 import com.codecool.getalife.controller.HobbyController;
+import com.codecool.getalife.exception.hobby.HobbyDuplicateException;
 import com.codecool.getalife.exception.hobby.HobbyNotFoundException;
 import com.codecool.getalife.model.dto.error.ErrorResponse;
 import org.springframework.http.HttpStatus;
@@ -24,5 +25,17 @@ public class HobbyControllerAdvice {
         );
 
         return ResponseEntity.status(HttpStatus.NOT_FOUND).body(error);
+    }
+
+    @ExceptionHandler(HobbyDuplicateException.class)
+    public ResponseEntity<ErrorResponse> handleDuplicate(HobbyDuplicateException ex) {
+
+        ErrorResponse error = new ErrorResponse(
+                HttpStatus.CONFLICT.value(),
+                ex.getMessage(),
+                LocalDateTime.now()
+        );
+
+        return ResponseEntity.status(HttpStatus.CONFLICT).body(error);
     }
 }

--- a/src/main/java/com/codecool/getalife/exception/hobby/HobbyDuplicateException.java
+++ b/src/main/java/com/codecool/getalife/exception/hobby/HobbyDuplicateException.java
@@ -1,0 +1,7 @@
+package com.codecool.getalife.exception.hobby;
+
+public class HobbyDuplicateException extends RuntimeException {
+    public HobbyDuplicateException(String hobbyName) {
+        super("Category already exists: " + hobbyName);
+    }
+}

--- a/src/main/java/com/codecool/getalife/service/HobbyService.java
+++ b/src/main/java/com/codecool/getalife/service/HobbyService.java
@@ -1,5 +1,6 @@
 package com.codecool.getalife.service;
 
+import com.codecool.getalife.exception.categories.CategoryDuplicateException;
 import com.codecool.getalife.exception.categories.CategoryNotFoundException;
 import com.codecool.getalife.exception.hobby.HobbyNotFoundException;
 import com.codecool.getalife.model.Category;
@@ -38,18 +39,22 @@ public class HobbyService {
         return toResponse(hobby);
     }
 
-    public HobbyResponse create(HobbyCreateRequest request) {
-        Set<Category> categories = request.categoryIds()
+    public HobbyResponse create(HobbyCreateRequest req) {
+
+        if (categoryRepository.existsCategoryByNameIgnoreCase(req.name())) {
+            throw new CategoryDuplicateException(req.name());
+        }
+        Set<Category> categories = req.categoryIds()
                 .stream()
                 .map(id -> categoryRepository.findById(id)
                         .orElseThrow(() -> new CategoryNotFoundException(id.toString())))
                 .collect(Collectors.toSet());
 
         Hobby hobby = Hobby.builder()
-                .name(request.name())
-                .description(request.description())
-                .min_price(request.minPrice())
-                .max_price(request.maxPrice())
+                .name(req.name())
+                .description(req.description())
+                .min_price(req.minPrice())
+                .max_price(req.maxPrice())
                 .categories(categories)
                 .build();
 


### PR DESCRIPTION
### Description

This pull request implements the following changes:

- Adds `HobbyDuplicateException` for detecting and handling duplicate Hobby creation, returning an HTTP 409 Conflict response.
- Introduces duplication validation logic in `HobbyService.create` method.
- Extends the Hobby feature with a creation DTO and implements a new endpoint for creating hobbies.
- Updates responses for Hobby and Category entities to include IDs.
- Adds the `Hobby` entity, its corresponding service, repository, controller, and initial exception handling.
- Removes the obsolete `PingController`.
- Refactors methods in `HobbyController` and `CategoryController` for improved readability. 

### Related issues

- None linked.

### Checklist

- [ ] Tested locally.
- [ ] Documentation updated, if needed.
- [ ] Unit tests added or updated.