### PR TITLE
Update duplicate validation logic in `HobbyService#create`

### DIFF
--- a/src/main/java/com/codecool/getalife/exception/hobby/HobbyDuplicateException.java
+++ b/src/main/java/com/codecool/getalife/exception/hobby/HobbyDuplicateException.java
@@ -2,6 +2,6 @@ package com.codecool.getalife.exception.hobby;
 
 public class HobbyDuplicateException extends RuntimeException {
     public HobbyDuplicateException(String hobbyName) {
-        super("Category already exists: " + hobbyName);
+        super("Hobby already exists: " + hobbyName);
     }
 }

--- a/src/main/java/com/codecool/getalife/service/HobbyService.java
+++ b/src/main/java/com/codecool/getalife/service/HobbyService.java
@@ -1,7 +1,7 @@
 package com.codecool.getalife.service;
 
-import com.codecool.getalife.exception.categories.CategoryDuplicateException;
 import com.codecool.getalife.exception.categories.CategoryNotFoundException;
+import com.codecool.getalife.exception.hobby.HobbyDuplicateException;
 import com.codecool.getalife.exception.hobby.HobbyNotFoundException;
 import com.codecool.getalife.model.Category;
 import com.codecool.getalife.model.Hobby;
@@ -40,26 +40,27 @@ public class HobbyService {
     }
 
     public HobbyResponse create(HobbyCreateRequest req) {
-
-        if (categoryRepository.existsCategoryByNameIgnoreCase(req.name())) {
-            throw new CategoryDuplicateException(req.name());
-        }
         Set<Category> categories = req.categoryIds()
                 .stream()
                 .map(id -> categoryRepository.findById(id)
                         .orElseThrow(() -> new CategoryNotFoundException(id.toString())))
                 .collect(Collectors.toSet());
 
-        Hobby hobby = Hobby.builder()
-                .name(req.name())
-                .description(req.description())
-                .min_price(req.minPrice())
-                .max_price(req.maxPrice())
-                .categories(categories)
-                .build();
+        try {
+            Hobby saved = hobbyRepository.save(Hobby.builder()
+                    .name(req.name())
+                    .description(req.description())
+                    .min_price(req.minPrice())
+                    .max_price(req.maxPrice())
+                    .categories(categories)
+                    .build());
+            return toResponse(saved);
+        } catch (Exception e) {
+            throw new HobbyDuplicateException(req.name());
+        }
 
-        Hobby savedHobby = hobbyRepository.save(hobby);
-        return toResponse(savedHobby);
+
+
     }
 
     private HobbyResponse toResponse(Hobby hobby) {


### PR DESCRIPTION
Refactored the `HobbyService#create` method to handle duplicate hobby creation using a dedicated `HobbyDuplicateException`. This replaces the previously misused `CategoryDuplicateException`. Additionally, adjusted the exception messaging for better clarity.