### PR TITLE
Handle missing category exception and improve hobby duplication check

### DIFF
--- a/src/main/java/com/codecool/getalife/controller/advice/HobbyControllerAdvice.java
+++ b/src/main/java/com/codecool/getalife/controller/advice/HobbyControllerAdvice.java
@@ -1,6 +1,7 @@
 package com.codecool.getalife.controller.advice;
 
 import com.codecool.getalife.controller.HobbyController;
+import com.codecool.getalife.exception.categories.CategoryNotFoundException;
 import com.codecool.getalife.exception.hobby.HobbyDuplicateException;
 import com.codecool.getalife.exception.hobby.HobbyNotFoundException;
 import com.codecool.getalife.model.dto.error.ErrorResponse;
@@ -37,5 +38,17 @@ public class HobbyControllerAdvice {
         );
 
         return ResponseEntity.status(HttpStatus.CONFLICT).body(error);
+    }
+
+    @ExceptionHandler(CategoryNotFoundException.class)
+    public ResponseEntity<ErrorResponse> handleCategoryNotFound(CategoryNotFoundException ex) {
+
+        ErrorResponse error = new ErrorResponse(
+                HttpStatus.BAD_REQUEST.value(),
+                ex.getMessage(),
+                LocalDateTime.now()
+        );
+
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(error);
     }
 }

--- a/src/main/java/com/codecool/getalife/controller/advice/HobbyControllerAdvice.java
+++ b/src/main/java/com/codecool/getalife/controller/advice/HobbyControllerAdvice.java
@@ -3,6 +3,7 @@ package com.codecool.getalife.controller.advice;
 import com.codecool.getalife.controller.HobbyController;
 import com.codecool.getalife.exception.categories.CategoryNotFoundException;
 import com.codecool.getalife.exception.hobby.HobbyDuplicateException;
+import com.codecool.getalife.exception.hobby.HobbyMissingCategoryException;
 import com.codecool.getalife.exception.hobby.HobbyNotFoundException;
 import com.codecool.getalife.model.dto.error.ErrorResponse;
 import org.springframework.http.HttpStatus;
@@ -42,6 +43,18 @@ public class HobbyControllerAdvice {
 
     @ExceptionHandler(CategoryNotFoundException.class)
     public ResponseEntity<ErrorResponse> handleCategoryNotFound(CategoryNotFoundException ex) {
+
+        ErrorResponse error = new ErrorResponse(
+                HttpStatus.BAD_REQUEST.value(),
+                ex.getMessage(),
+                LocalDateTime.now()
+        );
+
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(error);
+    }
+
+    @ExceptionHandler(HobbyMissingCategoryException.class)
+    public ResponseEntity<ErrorResponse> handleMissingCategory(HobbyMissingCategoryException ex) {
 
         ErrorResponse error = new ErrorResponse(
                 HttpStatus.BAD_REQUEST.value(),

--- a/src/main/java/com/codecool/getalife/exception/hobby/HobbyMissingCategoryException.java
+++ b/src/main/java/com/codecool/getalife/exception/hobby/HobbyMissingCategoryException.java
@@ -1,0 +1,7 @@
+package com.codecool.getalife.exception.hobby;
+
+public class HobbyMissingCategoryException extends RuntimeException {
+    public HobbyMissingCategoryException() {
+        super("A hobby must have at least one category");
+    }
+}

--- a/src/main/java/com/codecool/getalife/repository/HobbyRepository.java
+++ b/src/main/java/com/codecool/getalife/repository/HobbyRepository.java
@@ -3,4 +3,6 @@ package com.codecool.getalife.repository;
 import com.codecool.getalife.model.Hobby;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface HobbyRepository extends JpaRepository<Hobby, Long> {}
+public interface HobbyRepository extends JpaRepository<Hobby, Long> {
+    boolean existsByNameIgnoreCase(String name);
+}

--- a/src/main/java/com/codecool/getalife/service/HobbyService.java
+++ b/src/main/java/com/codecool/getalife/service/HobbyService.java
@@ -40,27 +40,26 @@ public class HobbyService {
     }
 
     public HobbyResponse create(HobbyCreateRequest req) {
+        if (hobbyRepository.existsByNameIgnoreCase(req.name())) {
+            throw new HobbyDuplicateException(req.name());
+        }
+
         Set<Category> categories = req.categoryIds()
                 .stream()
                 .map(id -> categoryRepository.findById(id)
                         .orElseThrow(() -> new CategoryNotFoundException(id.toString())))
                 .collect(Collectors.toSet());
 
-        try {
-            Hobby saved = hobbyRepository.save(Hobby.builder()
-                    .name(req.name())
-                    .description(req.description())
-                    .min_price(req.minPrice())
-                    .max_price(req.maxPrice())
-                    .categories(categories)
-                    .build());
-            return toResponse(saved);
-        } catch (Exception e) {
-            throw new HobbyDuplicateException(req.name());
-        }
+        Hobby hobby = Hobby.builder()
+                .name(req.name())
+                .description(req.description())
+                .min_price(req.minPrice())
+                .max_price(req.maxPrice())
+                .categories(categories)
+                .build();
 
-
-
+        Hobby savedHobby = hobbyRepository.save(hobby);
+        return toResponse(savedHobby);
     }
 
     private HobbyResponse toResponse(Hobby hobby) {

--- a/src/main/java/com/codecool/getalife/service/HobbyService.java
+++ b/src/main/java/com/codecool/getalife/service/HobbyService.java
@@ -2,6 +2,7 @@ package com.codecool.getalife.service;
 
 import com.codecool.getalife.exception.categories.CategoryNotFoundException;
 import com.codecool.getalife.exception.hobby.HobbyDuplicateException;
+import com.codecool.getalife.exception.hobby.HobbyMissingCategoryException;
 import com.codecool.getalife.exception.hobby.HobbyNotFoundException;
 import com.codecool.getalife.model.Category;
 import com.codecool.getalife.model.Hobby;
@@ -42,6 +43,10 @@ public class HobbyService {
     public HobbyResponse create(HobbyCreateRequest req) {
         if (hobbyRepository.existsByNameIgnoreCase(req.name())) {
             throw new HobbyDuplicateException(req.name());
+        }
+
+        if (req.categoryIds() == null || req.categoryIds().isEmpty()) {
+            throw new HobbyMissingCategoryException();
         }
 
         Set<Category> categories = req.categoryIds()


### PR DESCRIPTION
### Summary

- Added `CategoryNotFoundException` handling in `HobbyControllerAdvice` to ensure graceful failure with an HTTP 400 response for missing categories.
- Enhanced duplicate hobby validation by utilizing `existsByNameIgnoreCase` in `HobbyService#create`.
- Refactored hobby creation logic to simplify code by removing an unnecessary `try-catch` block.

### Checklist

- [x] Unit tests have been updated or added where necessary.
- [x] Documentation has been updated to reflect the changes as needed.