### PR TITLE
Add patch and delete functionality for Hobby entity

### DIFF
--- a/src/main/java/com/codecool/getalife/configuration/WebConfig.java
+++ b/src/main/java/com/codecool/getalife/configuration/WebConfig.java
@@ -1,4 +1,4 @@
-package com.codecool.getalife.config;
+package com.codecool.getalife.configuration;
 
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;

--- a/src/main/java/com/codecool/getalife/controller/HobbyController.java
+++ b/src/main/java/com/codecool/getalife/controller/HobbyController.java
@@ -1,6 +1,7 @@
 package com.codecool.getalife.controller;
 
 import com.codecool.getalife.model.dto.hobby.HobbyCreateRequest;
+import com.codecool.getalife.model.dto.hobby.HobbyPatchRequest;
 import com.codecool.getalife.model.dto.hobby.HobbyResponse;
 import com.codecool.getalife.service.HobbyService;
 import lombok.RequiredArgsConstructor;
@@ -33,5 +34,20 @@ public class HobbyController {
             @RequestPart("hobby") HobbyCreateRequest req,
             @RequestPart("image") MultipartFile img) {
         return ResponseEntity.status(HttpStatus.CREATED).body(hobbyService.create(req, img));
+    }
+
+    @PatchMapping(value = "/{id}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<HobbyResponse> patch(
+            @PathVariable Long id,
+            @RequestPart("hobby") HobbyPatchRequest req,
+            @RequestPart(value = "image", required = false) MultipartFile image) {
+
+        return ResponseEntity.ok(hobbyService.patch(id, req, image));
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> delete(@PathVariable Long id) {
+        hobbyService.delete(id);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/codecool/getalife/exception/storage/StorageException.java
+++ b/src/main/java/com/codecool/getalife/exception/storage/StorageException.java
@@ -1,0 +1,11 @@
+package com.codecool.getalife.exception.storage;
+
+public class StorageException extends RuntimeException {
+    public StorageException(String message) {
+        super(message);
+    }
+
+    public StorageException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/codecool/getalife/model/Hobby.java
+++ b/src/main/java/com/codecool/getalife/model/Hobby.java
@@ -2,17 +2,15 @@ package com.codecool.getalife.model;
 
 import com.codecool.getalife.common.BaseEntity;
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.util.HashSet;
 import java.util.Set;
 
 @Entity
 @Table(name = "hobbies")
-@Getter @NoArgsConstructor @AllArgsConstructor
+@Getter @Setter
+@NoArgsConstructor @AllArgsConstructor
 @Builder
 public class Hobby extends BaseEntity {
 

--- a/src/main/java/com/codecool/getalife/model/dto/hobby/HobbyPatchRequest.java
+++ b/src/main/java/com/codecool/getalife/model/dto/hobby/HobbyPatchRequest.java
@@ -1,0 +1,11 @@
+package com.codecool.getalife.model.dto.hobby;
+
+import java.util.Set;
+
+public record HobbyPatchRequest(
+        String name,
+        String description,
+        Set<Long> categoryIds,
+        Integer minPrice,
+        Integer maxPrice
+) {}

--- a/src/main/java/com/codecool/getalife/model/dto/hobby/HobbyResponse.java
+++ b/src/main/java/com/codecool/getalife/model/dto/hobby/HobbyResponse.java
@@ -5,6 +5,7 @@ import com.codecool.getalife.model.dto.category.CategoryNameResponse;
 import java.util.Set;
 
 public record HobbyResponse(
+        Long id,
         String name,
         String imageUrl,
         String description,

--- a/src/main/java/com/codecool/getalife/service/HobbyService.java
+++ b/src/main/java/com/codecool/getalife/service/HobbyService.java
@@ -76,6 +76,7 @@ public class HobbyService {
     private HobbyResponse toResponse(Hobby hobby) {
 
         return new HobbyResponse(
+                hobby.getId(),
                 hobby.getName(),
                 "/images/" + hobby.getImagePath(),
                 hobby.getDescription(),

--- a/src/main/java/com/codecool/getalife/service/HobbyService.java
+++ b/src/main/java/com/codecool/getalife/service/HobbyService.java
@@ -8,6 +8,7 @@ import com.codecool.getalife.model.Category;
 import com.codecool.getalife.model.Hobby;
 import com.codecool.getalife.model.dto.category.CategoryNameResponse;
 import com.codecool.getalife.model.dto.hobby.HobbyCreateRequest;
+import com.codecool.getalife.model.dto.hobby.HobbyPatchRequest;
 import com.codecool.getalife.model.dto.hobby.HobbyResponse;
 import com.codecool.getalife.repository.CategoryRepository;
 import com.codecool.getalife.repository.HobbyRepository;
@@ -73,6 +74,66 @@ public class HobbyService {
         return toResponse(savedHobby);
     }
 
+    public HobbyResponse patch(Long id, HobbyPatchRequest req, MultipartFile image) {
+
+        Hobby hobby = hobbyRepository.findById(id)
+                .orElseThrow(() -> new HobbyNotFoundException(id.toString()));
+
+        if (req.name() != null) {
+            if (!hobby.getName().equalsIgnoreCase(req.name())
+                    && hobbyRepository.existsByNameIgnoreCase(req.name())) {
+                throw new HobbyDuplicateException(req.name());
+            }
+            hobby.setName(req.name());
+        }
+
+        if (req.description() != null) {
+            hobby.setDescription(req.description());
+        }
+
+        if (req.minPrice() != null) {
+            hobby.setMin_price(req.minPrice());
+        }
+
+        if (req.maxPrice() != null) {
+            hobby.setMax_price(req.maxPrice());
+        }
+
+        if (req.categoryIds() != null) {
+            Set<Category> categories = req.categoryIds().stream()
+                    .map(catId -> categoryRepository.findById(catId)
+                            .orElseThrow(() -> new CategoryNotFoundException(catId.toString())))
+                    .collect(Collectors.toSet());
+
+            hobby.setCategories(categories);
+        }
+
+        if (image != null && !image.isEmpty()) {
+            if (hobby.getImagePath() != null) {
+                fileStorageService.delete(hobby.getImagePath());
+            }
+
+            String newImagePath = fileStorageService.store(image);
+            hobby.setImagePath(newImagePath);
+        }
+
+        Hobby updated = hobbyRepository.save(hobby);
+        return toResponse(updated);
+    }
+
+    public void delete(Long id) {
+        var hobby = hobbyRepository.findById(id).orElseThrow(
+                () -> new HobbyNotFoundException(id.toString())
+        );
+
+        if (hobby.getImagePath() != null) {
+            fileStorageService.delete(hobby.getImagePath());
+        }
+
+        hobbyRepository.delete(hobby);
+
+    }
+
     private HobbyResponse toResponse(Hobby hobby) {
 
         return new HobbyResponse(
@@ -88,4 +149,6 @@ public class HobbyService {
                 hobby.getMax_price()
         );
     }
+
+
 }

--- a/src/main/java/com/codecool/getalife/service/storage/FileStorageService.java
+++ b/src/main/java/com/codecool/getalife/service/storage/FileStorageService.java
@@ -4,4 +4,5 @@ import org.springframework.web.multipart.MultipartFile;
 
 public interface FileStorageService {
     String store(MultipartFile file);
+    void delete(String filename);
 }

--- a/src/main/java/com/codecool/getalife/service/storage/FileSystemStorageService.java
+++ b/src/main/java/com/codecool/getalife/service/storage/FileSystemStorageService.java
@@ -7,12 +7,13 @@ import org.springframework.web.multipart.MultipartFile;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.*;
+import java.util.Set;
 import java.util.UUID;
 
 @Service
 public class FileSystemStorageService implements FileStorageService {
 
-    private static final String DEFAULT_EXTENSION = "png";
+    private static final Set<String> ALLOWED_EXTENSIONS = Set.of("png", "jpg", "jpeg");
     private final Path rootLocation;
 
     public FileSystemStorageService() {
@@ -66,19 +67,32 @@ public class FileSystemStorageService implements FileStorageService {
         if (file == null || file.isEmpty()) {
             throw new StorageException("Cannot store empty file.");
         }
+
+        String contentType = file.getContentType();
+        if (contentType == null ||
+                (!contentType.equals("image/png") &&
+                        !contentType.equals("image/jpeg"))) {
+            throw new StorageException("Only PNG and JPG images are allowed.");
+        }
     }
 
     private String resolveExtension(String originalFilename) {
         if (originalFilename == null) {
-            return DEFAULT_EXTENSION;
+            throw new StorageException("File must have a valid name.");
         }
 
         int dotIndex = originalFilename.lastIndexOf('.');
         if (dotIndex < 0 || dotIndex == originalFilename.length() - 1) {
-            return DEFAULT_EXTENSION;
+            throw new StorageException("File must have an extension.");
         }
 
-        return originalFilename.substring(dotIndex + 1).toLowerCase();
+        String extension = originalFilename.substring(dotIndex + 1).toLowerCase();
+
+        if (!ALLOWED_EXTENSIONS.contains(extension)) {
+            throw new StorageException("Only PNG and JPG images are allowed.");
+        }
+
+        return extension;
     }
 
     private void ensureWithinStorage(Path path) {

--- a/src/main/java/com/codecool/getalife/service/storage/FileSystemStorageService.java
+++ b/src/main/java/com/codecool/getalife/service/storage/FileSystemStorageService.java
@@ -1,50 +1,89 @@
 package com.codecool.getalife.service.storage;
 
+import com.codecool.getalife.exception.storage.StorageException;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
+import java.io.InputStream;
+import java.nio.file.*;
 import java.util.UUID;
 
 @Service
 public class FileSystemStorageService implements FileStorageService {
 
-    private final Path rootLocation = Paths.get("uploads/hobbies");
+    private static final String DEFAULT_EXTENSION = "png";
+    private final Path rootLocation;
 
-    public FileSystemStorageService() throws IOException {
-        Files.createDirectories(rootLocation);
+    public FileSystemStorageService() {
+        this.rootLocation = Paths.get("uploads", "hobbies").toAbsolutePath().normalize();
+        init();
+    }
+
+    private void init() {
+        try {
+            Files.createDirectories(rootLocation);
+        } catch (IOException e) {
+            throw new StorageException("Could not initialize storage directory.", e);
+        }
     }
 
     @Override
     public String store(MultipartFile file) {
-        try {
-            if (file.isEmpty()) {
-                throw new RuntimeException("Failed to store empty file.");
-            }
+        validateFile(file);
 
-            String ext = getExtension(file.getOriginalFilename());
-            if (ext == null) {
-                ext = "png";
-            }
+        String extension = resolveExtension(file.getOriginalFilename());
+        String filename = UUID.randomUUID() + "." + extension;
 
-            String filename = UUID.randomUUID() + "." + ext;
-            Path destinationFile = rootLocation.resolve(filename);
+        Path destination = rootLocation.resolve(filename).normalize();
+        ensureWithinStorage(destination);
 
-            Files.copy(file.getInputStream(), destinationFile);
-
+        try (InputStream inputStream = file.getInputStream()) {
+            Files.copy(inputStream, destination, StandardCopyOption.REPLACE_EXISTING);
             return filename;
         } catch (IOException e) {
-            throw new RuntimeException("Failed to store file.", e);
+            throw new StorageException("Failed to store file.", e);
         }
     }
 
-    private String getExtension(String filename) {
-        if (filename == null) return null;
-        int dotIndex = filename.lastIndexOf('.');
-        if (dotIndex < 0) return null;
-        return filename.substring(dotIndex + 1);
+    @Override
+    public void delete(String filename) {
+        if (filename == null || filename.isBlank()) {
+            return;
+        }
+
+        Path file = rootLocation.resolve(filename).normalize();
+        ensureWithinStorage(file);
+
+        try {
+            Files.deleteIfExists(file);
+        } catch (IOException e) {
+            throw new StorageException("Failed to delete file: " + filename, e);
+        }
+    }
+
+    private void validateFile(MultipartFile file) {
+        if (file == null || file.isEmpty()) {
+            throw new StorageException("Cannot store empty file.");
+        }
+    }
+
+    private String resolveExtension(String originalFilename) {
+        if (originalFilename == null) {
+            return DEFAULT_EXTENSION;
+        }
+
+        int dotIndex = originalFilename.lastIndexOf('.');
+        if (dotIndex < 0 || dotIndex == originalFilename.length() - 1) {
+            return DEFAULT_EXTENSION;
+        }
+
+        return originalFilename.substring(dotIndex + 1).toLowerCase();
+    }
+
+    private void ensureWithinStorage(Path path) {
+        if (!path.startsWith(rootLocation)) {
+            throw new StorageException("Invalid file path.");
+        }
     }
 }


### PR DESCRIPTION
```
### Summary
This pull request introduces patch and delete functionality for the `Hobby` entity and enhances file storage with delete support.

### Changes
- Added `HobbyPatchRequest` to enable partial updates.
- Implemented `patch` and `delete` endpoints in `HobbyController`.
- Updated logic in `HobbyService` to handle patching and deletion, including managing associated images.
- Extended `FileStorageService` with a delete method and added path validation.
- Added an `id` field to `HobbyResponse`.
- Updated the package name in `WebConfig`.

### Checklist
- [ ] Tests for the added functionality are included.
- [ ] Documentation is updated as needed.
- [ ] Code follows project guidelines and standards.

```