### PR TITLE
Add difficulty field to hobby management

### DIFF
--- a/frontend/src/components/HobbyCard.jsx
+++ b/frontend/src/components/HobbyCard.jsx
@@ -23,6 +23,19 @@ function HobbyCard({hobby}){
         ? hobby.categories[0]?.name ?? String(hobby.categories[0])
         : "Category";
 
+    const getDifficultyColor = (difficultyLabel) => {
+        switch (difficultyLabel) {
+            case 'Beginner':
+                return 'bg-green-100 text-green-700';
+            case 'Intermediate':
+                return 'bg-yellow-100 text-yellow-700';
+            case 'Advanced':
+                return 'bg-red-100 text-red-700';
+            default:
+                return 'bg-gray-100 text-gray-700';
+        }
+    }
+
     const difficultyLabel = typeof hobby?.difficulty === "string" && hobby.difficulty.trim()
         ? hobby.difficulty
         : "Beginner";
@@ -68,7 +81,7 @@ function HobbyCard({hobby}){
                     )}
 
                     <div className="mt-1 flex items-center justify-between">
-                        <span className="badge badge-success badge-sm font-medium">
+                        <span className={`badge badge-sm font-medium ${getDifficultyColor(difficultyLabel)}`}>
                             {difficultyLabel}
                         </span>
                         {priceRange && (

--- a/frontend/src/components/HobbySection.jsx
+++ b/frontend/src/components/HobbySection.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { categoryApi, hobbyApi } from '../services/api.js';
+import Badge from "daisyui/components/badge/index.js";
 
 function HobbySection() {
   const initialFormState = {
@@ -7,13 +8,17 @@ function HobbySection() {
     categoryIds: [],
     min_price: 0,
     max_price: 0,
-    description: ''
+    description: '',
+    difficulty: ''
   };
   const [categories, setCategories] = useState([]);
+  const [selectedDifficulty, setSelectedDifficulty] = useState("Beginner");
   const [hobbies, setHobbies] = useState([]);
   const [formData, setFormData] = useState(initialFormState);
   const [selectedImage, setSelectedImage] = useState(null);
   const [editingId, setEditingId] = useState(null);
+
+  const difficulties = ["Beginner", "Intermediate", "Advanced"];
 
   useEffect(() => { loadAllData(); }, []);
 
@@ -89,6 +94,21 @@ function HobbySection() {
                     <option key={cat.id} value={cat.id}>{cat.name}</option>
                 ))}
               </select>
+            </div>
+
+            <div className="flex gap-2">
+              {difficulties.map((level) => (
+                  <button
+                      key={level}
+                      type="button"
+                      onClick={() => setFormData({ ...formData, difficulty: level })}
+                      className={`badge cursor-pointer ${
+                          formData.difficulty === level ? "badge-primary" : "badge-outline"
+                      }`}
+                  >
+                    {level}
+                  </button>
+              ))}
             </div>
 
             <div className="flex gap-2">

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -50,7 +50,8 @@ export const hobbyApi = {
       description: data.description,
       categoryIds: data.categoryIds,
       minPrice: data.minPrice,
-      maxPrice: data.maxPrice
+      maxPrice: data.maxPrice,
+      difficulty: data.difficulty
     })], { type: 'application/json' });
 
     formData.append('hobby', hobbyBlob);
@@ -76,7 +77,8 @@ export const hobbyApi = {
       description: data.description,
       categoryIds: data.categoryIds,
       minPrice: data.minPrice,
-      maxPrice: data.maxPrice
+      maxPrice: data.maxPrice,
+      difficulty: data.difficulty
     })], { type: 'application/json' });
 
     formData.append('hobby', hobbyBlob);

--- a/src/main/java/com/codecool/getalife/model/Hobby.java
+++ b/src/main/java/com/codecool/getalife/model/Hobby.java
@@ -29,6 +29,9 @@ public class Hobby extends BaseEntity {
     @Column(nullable = false)
     private Integer max_price;
 
+    @Column(nullable = false, columnDefinition = "varchar(255) default 'Beginner'")
+    private String difficulty;
+
     @ManyToMany
     @JoinTable(
             name = "hobby_categories",

--- a/src/main/java/com/codecool/getalife/model/dto/hobby/HobbyCreateRequest.java
+++ b/src/main/java/com/codecool/getalife/model/dto/hobby/HobbyCreateRequest.java
@@ -7,5 +7,6 @@ public record HobbyCreateRequest(
         String description,
         Set<Long> categoryIds,
         Integer minPrice,
-        Integer maxPrice
+        Integer maxPrice,
+        String difficulty
 ) {}

--- a/src/main/java/com/codecool/getalife/model/dto/hobby/HobbyPatchRequest.java
+++ b/src/main/java/com/codecool/getalife/model/dto/hobby/HobbyPatchRequest.java
@@ -7,5 +7,6 @@ public record HobbyPatchRequest(
         String description,
         Set<Long> categoryIds,
         Integer minPrice,
-        Integer maxPrice
+        Integer maxPrice,
+        String difficulty
 ) {}

--- a/src/main/java/com/codecool/getalife/model/dto/hobby/HobbyResponse.java
+++ b/src/main/java/com/codecool/getalife/model/dto/hobby/HobbyResponse.java
@@ -11,4 +11,6 @@ public record HobbyResponse(
         String description,
         Set<CategoryNameResponse> categories,
         Integer min_price,
-        Integer max_price) {}
+        Integer max_price,
+        String difficulty
+) {}

--- a/src/main/java/com/codecool/getalife/service/HobbyService.java
+++ b/src/main/java/com/codecool/getalife/service/HobbyService.java
@@ -68,6 +68,7 @@ public class HobbyService {
                 .min_price(req.minPrice())
                 .max_price(req.maxPrice())
                 .categories(categories)
+                .difficulty(req.difficulty())
                 .build();
 
         Hobby savedHobby = hobbyRepository.save(hobby);
@@ -146,7 +147,8 @@ public class HobbyService {
                         .map(category -> new CategoryNameResponse(category.getId(), category.getName()))
                         .collect(Collectors.toSet()),
                 hobby.getMin_price(),
-                hobby.getMax_price()
+                hobby.getMax_price(),
+                hobby.getDifficulty()
         );
     }
 


### PR DESCRIPTION
### Description

This pull request introduces a `difficulty` field for hobbies, updated across both the backend and frontend:

- **Backend**: Extended `Hobby` entity, DTOs, and related services to include the `difficulty` property.
- **Frontend**: Updated `HobbySection` to allow difficulty selection using badges and enhanced `HobbyCard` to display difficulty with dynamic colors.
- Adjusted API handling for seamless integration of the `difficulty` field.

No breaking changes are introduced.