### PR TITLE
Ensure repository changes are flushed after seeding categories

### DIFF
--- a/src/main/java/com/codecool/getalife/configuration/DataSeeder.java
+++ b/src/main/java/com/codecool/getalife/configuration/DataSeeder.java
@@ -39,6 +39,7 @@ public class DataSeeder implements ApplicationRunner {
                 .filter(name -> !categoryRepository.existsCategoryByNameIgnoreCase(name))
                 .map(name -> Category.builder().name(name).build())
                 .forEach(categoryRepository::save);
+        categoryRepository.flush();
         log.info("Categories seeded.");
     }
 


### PR DESCRIPTION
No specific template details were supplied. If a description is necessary, here’s an overview:

This pull request ensures that the `categoryRepository` properly flushes changes to the database after seeding categories. This prevents potential stale data or unexpected behavior due to unflushed repository states.